### PR TITLE
Potential fix for code scanning alert no. 10: Incorrect conversion between integer types

### DIFF
--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -336,7 +336,7 @@ func parseExtAddr(spec string) (ip net.IP, port int, ok bool) {
 		return nil, 0, false
 	}
 	port, err = strconv.Atoi(portstr)
-	if err != nil {
+	if err != nil || port < 0 || port > 65535 {
 		return nil, 0, false
 	}
 	return ip, port, true


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/10](https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/10)

To fix the issue, we need to ensure that the `port` value is validated before being converted to `uint16`. Specifically:
1. Add a bounds check in the `parseExtAddr` function to ensure that the parsed `port` value is within the range 0–65535.
2. If the `port` value is out of bounds, return an error or handle it appropriately to prevent invalid data from propagating to `SetFallbackUDP`.

This fix ensures that the conversion to `uint16` in `SetFallbackUDP` is safe and does not result in unexpected behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
