### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/console/prompt"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
+	"regexp"
 )
 
 type CommandlineUI struct {
@@ -237,7 +238,9 @@ func (ui *CommandlineUI) ShowError(message string) {
 
 // ShowInfo displays info message to user
 func (ui *CommandlineUI) ShowInfo(message string) {
-	fmt.Printf("## Info \n%s\n", message)
+	// Redact sensitive data from the message
+	redactedMessage := sanitizeMessage(message)
+	fmt.Printf("## Info \n%s\n", redactedMessage)
 }
 
 func (ui *CommandlineUI) OnApprovedTx(tx ethapi.SignTransactionResult) {
@@ -278,4 +281,10 @@ func (ui *CommandlineUI) OnSignerStartup(info StartupInfo) {
 		fmt.Printf("* %v : %v\n", k, v)
 	}
 	go ui.showAccounts()
+}
+// sanitizeMessage redacts sensitive data such as passwords from the input message.
+func sanitizeMessage(message string) string {
+	// Example: Redact anything that looks like a password (e.g., "password=...")
+	re := regexp.MustCompile(`(?i)(password\s*=\s*).*?(\s|$)`)
+	return re.ReplaceAllString(message, "${1}[REDACTED]${2}")
 }


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/7](https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/7)

To fix the issue, we need to ensure that sensitive data is not logged in clear text. This can be achieved by obfuscating or redacting sensitive information before it is passed to the `ShowInfo` method. Specifically:

1. Modify the `ShowInfo` method in `signer/core/cliui.go` to sanitize the `message` parameter by redacting sensitive data.
2. Ensure that any sensitive data, such as passwords, is either excluded or replaced with a placeholder (e.g., `"[REDACTED]"`) before being logged.

This approach ensures that sensitive information is not exposed in logs while maintaining the functionality of the `ShowInfo` method for non-sensitive messages.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
