### PR TITLE
Potential fix for code scanning alert no. 5: Size computation for allocation may overflow

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -81,11 +81,14 @@ func MustDecode(input string) []byte {
 }
 
 // Encode encodes b as a hex string with 0x prefix.
-func Encode(b []byte) string {
+func Encode(b []byte) (string, error) {
+	if len(b) > (math.MaxInt/2 - 1) {
+		return "", fmt.Errorf("input too large to encode")
+	}
 	enc := make([]byte, len(b)*2+2)
 	copy(enc, "0x")
 	hex.Encode(enc[2:], b)
-	return string(enc)
+	return string(enc), nil
 }
 
 // DecodeUint64 decodes a hex string with 0x prefix as a quantity.

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -550,8 +550,12 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 	if err != nil {
 		return nil, err
 	}
+	encodedBlob, err := hexutil.Encode(blob)
+	if err != nil {
+		return nil, err
+	}
 	batch := db.NewBatch()
-	rawdb.WriteGenesisStateSpec(batch, block.Hash(), blob)
+	rawdb.WriteGenesisStateSpec(batch, block.Hash(), []byte(encodedBlob))
 	rawdb.WriteBlock(batch, block)
 	rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), nil)
 	rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -353,7 +353,11 @@ type StorageResult struct {
 type proofList []string
 
 func (n *proofList) Put(key []byte, value []byte) error {
-	*n = append(*n, hexutil.Encode(value))
+	encodedValue, err := hexutil.Encode(value)
+	if err != nil {
+		return err
+	}
+	*n = append(*n, encodedValue)
 	return nil
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/5](https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/5)

To fix the issue, we need to ensure that the size computation `len(b)*2` does not overflow. This can be achieved by validating the length of `b` before performing the multiplication. Specifically:
1. Check if `len(b)` exceeds a safe threshold (e.g., `math.MaxInt/2 - 1`), which would ensure that the multiplication and subsequent addition (`+2`) do not overflow.
2. If the length exceeds the threshold, return an error or handle the case appropriately.

This fix should be applied in the `Encode` function in `common/hexutil/hexutil.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
