### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/1](https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply to all jobs. Since the workflow only performs linting and testing, it does not require write permissions. We will set `contents: read` as the minimal required permission. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
