### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -282,9 +282,18 @@ func (ui *CommandlineUI) OnSignerStartup(info StartupInfo) {
 	}
 	go ui.showAccounts()
 }
-// sanitizeMessage redacts sensitive data such as passwords from the input message.
+// sanitizeMessage redacts sensitive data such as passwords, API keys, and tokens from the input message.
 func sanitizeMessage(message string) string {
-	// Example: Redact anything that looks like a password (e.g., "password=...")
-	re := regexp.MustCompile(`(?i)(password\s*=\s*).*?(\s|$)`)
-	return re.ReplaceAllString(message, "${1}[REDACTED]${2}")
+	// Define patterns for sensitive data (e.g., passwords, API keys, tokens).
+	patterns := []string{
+		`(?i)(password\s*=\s*).*?(\s|$)`,       // Matches "password=..."
+		`(?i)(api[-_]?key\s*=\s*).*?(\s|$)`,    // Matches "apiKey=..." or "api-key=..."
+		`(?i)(token\s*=\s*).*?(\s|$)`,          // Matches "token=..."
+	}
+	redactedMessage := message
+	for _, pattern := range patterns {
+		re := regexp.MustCompile(pattern)
+		redactedMessage = re.ReplaceAllString(redactedMessage, "${1}[REDACTED]${2}")
+	}
+	return redactedMessage
 }


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/11](https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/11)

To fix the issue, we need to ensure that sensitive data is comprehensively redacted or omitted before being logged. The `sanitizeMessage` function should be enhanced to handle a broader range of sensitive data patterns. Additionally, we should avoid logging sensitive data altogether when possible. Specifically:

1. Enhance the `sanitizeMessage` function to redact a wider range of sensitive data patterns, such as API keys, tokens, and other credentials.
2. Ensure that any sensitive data passed to `ShowInfo` is either redacted or omitted entirely.
3. Add comments and documentation to clarify the purpose of `sanitizeMessage` and its limitations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
