### PR TITLE
Potential fix for code scanning alert no. 4: Size computation for allocation may overflow

### DIFF
--- a/accounts/usbwallet/trezor.go
+++ b/accounts/usbwallet/trezor.go
@@ -294,6 +294,9 @@ func (w *trezorDriver) trezorExchange(req proto.Message, results ...proto.Messag
 	if err != nil {
 		return 0, err
 	}
+	if len(data) > 64*1024*1024 { // 64 MB limit
+		return 0, errors.New("message size exceeds maximum allowable limit")
+	}
 	payload := make([]byte, 8+len(data))
 	copy(payload, []byte{0x23, 0x23})
 	binary.BigEndian.PutUint16(payload[2:], trezor.Type(req))


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/4](https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/4)

To fix the issue, we need to ensure that the size of `data` (produced by `proto.Marshal(req)`) is validated before performing arithmetic operations or using it in a slice allocation. Specifically:
1. Introduce a maximum allowable size for `data` to prevent overflow. For example, we can define a limit such as 64 MB (or another appropriate value based on the application's requirements).
2. Check the length of `data` after marshaling `req`. If it exceeds the maximum allowable size, return an error.
3. Proceed with the allocation and subsequent operations only if the size is within the safe range.

This approach ensures that the allocation on line 297 is safe and prevents potential overflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
