### PR TITLE
Potential fix for code scanning alert no. 12: Clear-text logging of sensitive information

### DIFF
--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -39,9 +39,9 @@ func sanitizeMessage(message string) string {
 		pattern string
 		repl    string
 	}{
-		{`(?i)password\s*:\s*\S+`, "password: [REDACTED]"},
-		{`(?i)private\s*key\s*:\s*\S+`, "private key: [REDACTED]"},
-		{`(?i)secret\s*:\s*\S+`, "secret: [REDACTED]"},
+		{`(?i)password\s*:\s*(?:"[^"]*"|\S.*)`, "password: [REDACTED]"},
+		{`(?i)private\s*key\s*:\s*(?:"[^"]*"|\S.*)`, "private key: [REDACTED]"},
+		{`(?i)secret\s*:\s*(?:"[^"]*"|\S.*)`, "secret: [REDACTED]"},
 	}
 	for _, r := range replacements {
 		re := regexp.MustCompile(r.pattern)

--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -33,8 +34,20 @@ import (
 
 // sanitizeMessage redacts sensitive information from the input string.
 func sanitizeMessage(message string) string {
-	// Example: Replace occurrences of "password: <value>" with "password: [REDACTED]"
-	return strings.ReplaceAll(message, "password:", "password: [REDACTED]")
+	// Redact common sensitive data patterns using regular expressions.
+	replacements := []struct {
+		pattern string
+		repl    string
+	}{
+		{`(?i)password\s*:\s*\S+`, "password: [REDACTED]"},
+		{`(?i)private\s*key\s*:\s*\S+`, "private key: [REDACTED]"},
+		{`(?i)secret\s*:\s*\S+`, "secret: [REDACTED]"},
+	}
+	for _, r := range replacements {
+		re := regexp.MustCompile(r.pattern)
+		message = re.ReplaceAllString(message, r.repl)
+	}
+	return message
 }
 
 type CommandlineUI struct {


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/12](https://github.com/roseteromeo56-cb-id/go-ethereum/security/code-scanning/12)

To address the issue, we need to ensure that sensitive information is properly sanitized or redacted before being logged. The `sanitizeMessage` function should be enhanced to handle a broader range of sensitive data patterns. Additionally, we should review the flow of data to `ShowInfo` to ensure that sensitive information is not inadvertently passed to it.

**Steps to fix:**
1. Enhance the `sanitizeMessage` function to redact common sensitive data patterns, such as passwords, private keys, and other sensitive fields.
2. Use a more robust approach, such as regular expressions, to identify and redact sensitive information.
3. Ensure that all calls to `ShowInfo` pass sanitized or non-sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
